### PR TITLE
Fix for: AttributeError: 'module' object has no attribute 'CodeView'

### DIFF
--- a/visualtitle/views.py
+++ b/visualtitle/views.py
@@ -18,7 +18,7 @@ from interfaces import IAddonSpecific
 grok.layer(IAddonSpecific)
 
 
-class VisualTitle(grok.CodeView):
+class VisualTitle(grok.View):
     """
     Extracts visual title from the content.
     """


### PR DESCRIPTION
Proposed fix for Issue #3.
Works on Plone 4.3.2
